### PR TITLE
add common.h; fix a bug in modrm

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,17 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+typedef unsigned char u1;
+typedef unsigned short u2;
+typedef unsigned int u4;
+typedef char s1;
+typedef short s2;
+typedef int s4;
+typedef unsigned char bool;
+typedef unsigned int uint;
+
+#define MASKN(n) ((1<<(n))-1)
+#define LSB16(v) (*(u2*)(v))
+#define LSB32(v) (*(u4*)(v))
+
+#endif

--- a/src/x86dis.h
+++ b/src/x86dis.h
@@ -218,11 +218,10 @@ typedef enum {
 
 #define X86_DIS_NH		-1
 
-// decodes one x86 instruction into 'ins' and returns its size
 void x86init(); // setup local opcode tables
+// decodes one x86 instruction into 'ins' and returns its size
 int x86dis(x86_inst *ins, u1 *p, bool bits32);
 // converts x86_inst to mnemonic
 char *x86mnemonize(char *out, x86_inst *inst, bool att);
 
 #endif
-


### PR DESCRIPTION
* "common.h" is missing in the original repository. I tried to infer the missing macros and typedefs and put these in this file.
* Fixed a bug in the code dealing with modrm byte in `x86dis`: 
     
    ```
    ... // Around line 516
    ...
	} else if(mod || rm != 5) {
	    d.mem.base = reg+eAX;  // reg should be rm
	}
    ``` 
